### PR TITLE
Moveable block

### DIFF
--- a/Assets/Props/TestBlock.prefab
+++ b/Assets/Props/TestBlock.prefab
@@ -1,0 +1,124 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4023196191139440745
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9156058134560589283}
+  - component: {fileID: 5808278372465347965}
+  - component: {fileID: 169564998359406466}
+  - component: {fileID: -4533983657914045578}
+  - component: {fileID: 6626946522471438856}
+  m_Layer: 0
+  m_Name: TestBlock
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9156058134560589283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4023196191139440745}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5808278372465347965
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4023196191139440745}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &169564998359406466
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4023196191139440745}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: -2853538094116638042, guid: 017e9d5e0baaa6d41a64731e0ea3df1b, type: 3}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &-4533983657914045578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4023196191139440745}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4c801586c48632c488856997f2d98466, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 9
+--- !u!65 &6626946522471438856
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4023196191139440745}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.4, y: 1.4, z: 1.4}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Props/TestBlock.prefab.meta
+++ b/Assets/Props/TestBlock.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2c89201b7e505aa488c95e98dada18ae
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/LevelBlockOut.unity
+++ b/Assets/Scenes/LevelBlockOut.unity
@@ -2924,17 +2924,17 @@ PrefabInstance:
     - target: {fileID: -775069670341356040, guid: 0c99fd8773f44d4419783835359ad994,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.1667
+      value: -0.1696
       objectReference: {fileID: 0}
     - target: {fileID: -775069670341356040, guid: 0c99fd8773f44d4419783835359ad994,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -775069670341356040, guid: 0c99fd8773f44d4419783835359ad994,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.093
+      value: 0.0421
       objectReference: {fileID: 0}
     - target: {fileID: -775069670341356040, guid: 0c99fd8773f44d4419783835359ad994,
         type: 3}
@@ -3031,31 +3031,10 @@ PrefabInstance:
     - {fileID: 2800250516343163423, guid: 0c99fd8773f44d4419783835359ad994, type: 3}
     - {fileID: 8485173162082002552, guid: 0c99fd8773f44d4419783835359ad994, type: 3}
     - {fileID: 6512510688612296998, guid: 0c99fd8773f44d4419783835359ad994, type: 3}
+    - {fileID: -6763858364670572316, guid: 0c99fd8773f44d4419783835359ad994, type: 3}
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: -6763858364670572316, guid: 0c99fd8773f44d4419783835359ad994,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 288362975}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0c99fd8773f44d4419783835359ad994, type: 3}
---- !u!1 &288362973 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: -6763858364670572316, guid: 0c99fd8773f44d4419783835359ad994,
-    type: 3}
-  m_PrefabInstance: {fileID: 288362971}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &288362975
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 288362973}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1db796aa2be3bda4c9b3221b64bfff67, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &309186929
 GameObject:
   m_ObjectHideFlags: 0
@@ -17397,6 +17376,89 @@ Transform:
   m_Children: []
   m_Father: {fileID: 283808462}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &5265142020519001376
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4023196191139440745, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_Name
+      value: TestBlock
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 44.868164
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 44.868153
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 44.868164
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -129.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.3999996
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.016898217
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.99985725
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156058134560589283, guid: 2c89201b7e505aa488c95e98dada18ae,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2c89201b7e505aa488c95e98dada18ae, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -17435,5 +17497,6 @@ SceneRoots:
   - {fileID: 3113576}
   - {fileID: 1815846428}
   - {fileID: 1678458218}
+  - {fileID: 5265142020519001376}
   - {fileID: 268667243}
   - {fileID: 1449003750}

--- a/Assets/Scripts/InteractiveObjs.meta
+++ b/Assets/Scripts/InteractiveObjs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a0867b33ca3b6341a6bbb3d695f7201
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/InteractiveObjs/InteractiveBlock.cs
+++ b/Assets/Scripts/InteractiveObjs/InteractiveBlock.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+public class InteractiveBlock : MonoBehaviour
+{
+    public float moveSpeed = 2f;
+
+    private Vector3 moveDirection = Vector3.zero;
+    private bool isColliding = false;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        moveDirection = (transform.position - other.transform.position);
+        moveDirection.y = 0f;
+        moveDirection.Normalize();
+
+        isColliding = true;
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        isColliding = false;
+        moveDirection = Vector3.zero;
+    }
+
+    private void Update()
+    {
+        if (isColliding)
+        {
+            transform.position += moveDirection * moveSpeed * Time.deltaTime;
+        }
+    }
+}

--- a/Assets/Scripts/InteractiveObjs/InteractiveBlock.cs.meta
+++ b/Assets/Scripts/InteractiveObjs/InteractiveBlock.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c801586c48632c488856997f2d98466


### PR DESCRIPTION
Creates a script that can be attached to a block to move it around when a player collides with it.

## Testing <!-- written by Kyle and Jenna using Jenna's acct -->
- Pull the prefab `TestBlock` from `Assets/Props` into the scene
- Scale the block to 4x on all axis
- Play and walk into the block