### PR TITLE
Health and hazards

### DIFF
--- a/Assets/Damagables.meta
+++ b/Assets/Damagables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 231c2ca71bd4cb8499100e96dacf4b70
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/LevelBlockOut.unity
+++ b/Assets/Scenes/LevelBlockOut.unity
@@ -2450,6 +2450,57 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1234221464}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &223150765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 223150766}
+  - component: {fileID: 223150767}
+  m_Layer: 0
+  m_Name: SpawnPoints
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &223150766
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223150765}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1925176809}
+  - {fileID: 760503865}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &223150767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223150765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af7ab404c06d0c14ca3a7b707cf0f899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healthManager: {fileID: 1911745955}
+  spawnPoints:
+  - {fileID: 1925176809}
+  - {fileID: 0}
+  - {fileID: 0}
 --- !u!1 &226660242 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: b2340bd1f680a3a4fa736617255bb2de,
@@ -4549,6 +4600,81 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Hearts Appear When Game Is Played
+--- !u!1 &562356226
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 562356227}
+  - component: {fileID: 562356229}
+  - component: {fileID: 562356228}
+  m_Layer: 0
+  m_Name: DeathBlackScreen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &562356227
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 562356226}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1490730482}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &562356228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 562356226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &562356229
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 562356226}
+  m_CullTransparentMesh: 1
 --- !u!1001 &569543849
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5359,6 +5485,73 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 30f84ca2b5c5c7e4fb5cbd1ef1b464c4, type: 3}
+--- !u!1 &760503864
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 760503865}
+  - component: {fileID: 760503867}
+  - component: {fileID: 760503866}
+  m_Layer: 0
+  m_Name: BookshelfSpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &760503865
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 760503864}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -27.65, y: 0, z: 42.42}
+  m_LocalScale: {x: 31.608953, y: 11.412, z: 69.10979}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 223150766}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &760503866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 760503864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ef510a15720246d43bd8dadaaadeb5c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spawnPointManager: {fileID: 0}
+--- !u!65 &760503867
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 760503864}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &778968509
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7911,7 +8104,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1012411805}
   - component: {fileID: 1012411807}
-  - component: {fileID: 1012411806}
   m_Layer: 0
   m_Name: Hearts
   m_TagString: Untagged
@@ -7939,22 +8131,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1012411806
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1012411804}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f81640f39f926ce449ecb17506d3e6dc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  OnHealthChange:
-    m_PersistentCalls:
-      m_Calls: []
-  maxHealth: 3
 --- !u!114 &1012411807
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7967,11 +8143,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2682b68b71b5bf34c814207e4ed321cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthManager: {fileID: 1012411806}
+  healthManager: {fileID: 1911745955}
   heartPrefab: {fileID: 4817011841326584750, guid: ad14ff4505b392544b32062ab37aa143,
     type: 3}
   heartDisplayOffset: 50
   heartDisplayPos: {fileID: 546419655}
+  deathScreen: {fileID: 562356228}
 --- !u!1 &1013350918
 GameObject:
   m_ObjectHideFlags: 0
@@ -12267,6 +12444,7 @@ RectTransform:
   - {fileID: 1012411805}
   - {fileID: 1902370138}
   - {fileID: 253277074}
+  - {fileID: 562356227}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -15206,9 +15384,10 @@ GameObject:
   - component: {fileID: 1911745953}
   - component: {fileID: 1911745952}
   - component: {fileID: 1911745951}
+  - component: {fileID: 1911745955}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -15325,6 +15504,31 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1911745955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1911745949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f81640f39f926ce449ecb17506d3e6dc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageTag: Damager
+  maxHealth: 3
+  deathFadeTimer: 1.2
+  fullFadeWait: 2
+  OnHealthChange:
+    m_PersistentCalls:
+      m_Calls: []
+  OnDie:
+    m_PersistentCalls:
+      m_Calls: []
+  StartDeathFade:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &1920553062
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15462,6 +15666,73 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1920553062}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1925176808
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1925176809}
+  - component: {fileID: 1925176810}
+  - component: {fileID: 1925176811}
+  m_Layer: 0
+  m_Name: UnderBedSpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1925176809
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1925176808}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 17, y: 0, z: -57}
+  m_LocalScale: {x: 42.41498, y: 11.412, z: 37.082035}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 223150766}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1925176810
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1925176808}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1925176811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1925176808}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ef510a15720246d43bd8dadaaadeb5c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spawnPointManager: {fileID: 0}
 --- !u!1001 &1927233837
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16558,6 +16829,114 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2064909960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2064909964}
+  - component: {fileID: 2064909963}
+  - component: {fileID: 2064909962}
+  - component: {fileID: 2064909961}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Damager
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &2064909961
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2064909960}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2064909962
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2064909960}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2064909963
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2064909960}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2064909964
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2064909960}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 17.39, y: 0.5, z: -51.33}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2076263512
 GameObject:
   m_ObjectHideFlags: 0
@@ -17324,3 +17703,5 @@ SceneRoots:
   - {fileID: 1678458218}
   - {fileID: 268667243}
   - {fileID: 1449003750}
+  - {fileID: 2064909964}
+  - {fileID: 223150766}

--- a/Assets/Scenes/LevelBlockOut.unity
+++ b/Assets/Scenes/LevelBlockOut.unity
@@ -4480,6 +4480,7 @@ GameObject:
   m_Component:
   - component: {fileID: 546419655}
   - component: {fileID: 546419656}
+  - component: {fileID: 546419657}
   m_Layer: 0
   m_Name: HeartPos
   m_TagString: Untagged
@@ -4514,6 +4515,40 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 546419654}
   m_CullTransparentMesh: 0
+--- !u!114 &546419657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 546419654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Hearts Appear When Game Is Played
 --- !u!1001 &569543849
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15023,7 +15058,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1902370138}
   m_Layer: 0
-  m_Name: Hearts (1)
+  m_Name: Controls
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scenes/LevelBlockOut.unity
+++ b/Assets/Scenes/LevelBlockOut.unity
@@ -12932,6 +12932,114 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1875471358}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1580260140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1580260144}
+  - component: {fileID: 1580260143}
+  - component: {fileID: 1580260142}
+  - component: {fileID: 1580260141}
+  m_Layer: 0
+  m_Name: HazardExample
+  m_TagString: Hazard
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1580260141
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580260140}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1580260142
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580260140}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1580260143
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580260140}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1580260144
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580260140}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 15.39, y: 0.19, z: -11.61}
+  m_LocalScale: {x: 2, y: 0.25, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1583756745
 GameObject:
   m_ObjectHideFlags: 0
@@ -15512,7 +15620,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f81640f39f926ce449ecb17506d3e6dc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damageTag: Damager
+  damageTag: Hazard
   maxHealth: 3
   deathFadeTimer: 1.2
   fullFadeWait: 2
@@ -17592,3 +17700,4 @@ SceneRoots:
   - {fileID: 268667243}
   - {fileID: 1449003750}
   - {fileID: 223150766}
+  - {fileID: 1580260144}

--- a/Assets/Scenes/LevelBlockOut.unity
+++ b/Assets/Scenes/LevelBlockOut.unity
@@ -4470,6 +4470,50 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 522794169}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &546419654
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 546419655}
+  - component: {fileID: 546419656}
+  m_Layer: 0
+  m_Name: HeartPos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &546419655
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 546419654}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.000010860349}
+  m_LocalScale: {x: 1.1853164, y: 1.1853163, z: 1.1853163}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1012411805}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -360, y: 181}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &546419656
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 546419654}
+  m_CullTransparentMesh: 0
 --- !u!1001 &569543849
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7831,6 +7875,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1012411805}
+  - component: {fileID: 1012411807}
+  - component: {fileID: 1012411806}
   m_Layer: 0
   m_Name: Hearts
   m_TagString: Untagged
@@ -7850,9 +7896,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1448211110}
-  - {fileID: 1066669757}
-  - {fileID: 1346969544}
+  - {fileID: 546419655}
   m_Father: {fileID: 1490730482}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -7860,6 +7904,39 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1012411806
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012411804}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f81640f39f926ce449ecb17506d3e6dc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnHealthChange:
+    m_PersistentCalls:
+      m_Calls: []
+  maxHealth: 3
+--- !u!114 &1012411807
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012411804}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2682b68b71b5bf34c814207e4ed321cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healthManager: {fileID: 1012411806}
+  heartPrefab: {fileID: 4817011841326584750, guid: ad14ff4505b392544b32062ab37aa143,
+    type: 3}
+  heartDisplayOffset: 50
+  heartDisplayPos: {fileID: 546419655}
 --- !u!1 &1013350918
 GameObject:
   m_ObjectHideFlags: 0
@@ -8184,81 +8261,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1056204438}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1066669756
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1066669757}
-  - component: {fileID: 1066669759}
-  - component: {fileID: 1066669758}
-  m_Layer: 0
-  m_Name: HeartTwo
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1066669757
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1066669756}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.000010860349}
-  m_LocalScale: {x: 1.1853164, y: 1.1853163, z: 1.1853163}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1012411805}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -310, y: 181}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1066669758
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1066669756}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 05eb93f533071b6478416d5a83d6221e, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1066669759
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1066669756}
-  m_CullTransparentMesh: 0
 --- !u!1 &1074099460
 GameObject:
   m_ObjectHideFlags: 0
@@ -10574,81 +10576,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!1 &1346969543
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1346969544}
-  - component: {fileID: 1346969546}
-  - component: {fileID: 1346969545}
-  m_Layer: 0
-  m_Name: HeartThree
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1346969544
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1346969543}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.000010860349}
-  m_LocalScale: {x: 1.1853164, y: 1.1853163, z: 1.1853163}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1012411805}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -260, y: 181}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1346969545
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1346969543}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 05eb93f533071b6478416d5a83d6221e, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1346969546
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1346969543}
-  m_CullTransparentMesh: 0
 --- !u!1 &1371927584
 GameObject:
   m_ObjectHideFlags: 0
@@ -11923,81 +11850,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1448153904}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1448211109
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1448211110}
-  - component: {fileID: 1448211112}
-  - component: {fileID: 1448211111}
-  m_Layer: 0
-  m_Name: HeartOne
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1448211110
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1448211109}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.000010860349}
-  m_LocalScale: {x: 1.1853164, y: 1.1853163, z: 1.1853163}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1012411805}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -360, y: 181}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1448211111
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1448211109}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 05eb93f533071b6478416d5a83d6221e, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1448211112
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1448211109}
-  m_CullTransparentMesh: 0
 --- !u!1001 &1449003750
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/LevelBlockOut.unity
+++ b/Assets/Scenes/LevelBlockOut.unity
@@ -12966,7 +12966,7 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3

--- a/Assets/Scenes/LevelBlockOut.unity
+++ b/Assets/Scenes/LevelBlockOut.unity
@@ -2497,10 +2497,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   healthManager: {fileID: 1911745955}
-  spawnPoints:
-  - {fileID: 1925176809}
-  - {fileID: 0}
-  - {fileID: 0}
 --- !u!1 &226660242 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: b2340bd1f680a3a4fa736617255bb2de,
@@ -5530,7 +5526,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ef510a15720246d43bd8dadaaadeb5c9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  spawnPointManager: {fileID: 0}
+  spawnPointManager: {fileID: 223150767}
 --- !u!65 &760503867
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -15732,7 +15728,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ef510a15720246d43bd8dadaaadeb5c9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  spawnPointManager: {fileID: 0}
+  spawnPointManager: {fileID: 223150767}
 --- !u!1001 &1927233837
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16829,114 +16825,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2064909960
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2064909964}
-  - component: {fileID: 2064909963}
-  - component: {fileID: 2064909962}
-  - component: {fileID: 2064909961}
-  m_Layer: 0
-  m_Name: Cube
-  m_TagString: Damager
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &2064909961
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2064909960}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &2064909962
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2064909960}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &2064909963
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2064909960}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &2064909964
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2064909960}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 17.39, y: 0.5, z: -51.33}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2076263512
 GameObject:
   m_ObjectHideFlags: 0
@@ -17703,5 +17591,4 @@ SceneRoots:
   - {fileID: 1678458218}
   - {fileID: 268667243}
   - {fileID: 1449003750}
-  - {fileID: 2064909964}
   - {fileID: 223150766}

--- a/Assets/Scripts/Health And Hazzards.meta
+++ b/Assets/Scripts/Health And Hazzards.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd17f6c86065c6b489f3ec70dce082a4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
+++ b/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public class HealthDisplayManager : MonoBehaviour
+{
+    [SerializeField] private HealthManager healthManager;
+    [SerializeField] private GameObject heartPrefab;
+    [SerializeField] private float heartDisplayOffset;
+    [SerializeField] private Transform heartDisplayPos;
+    private List<GameObject> displayHearts = new List<GameObject>();
+
+    private void Awake()
+    {
+        healthManager.OnHealthChange.AddListener(OnHealthUpdate);
+    }
+
+    private void OnHealthUpdate(int oldHealth, int newHealth)
+    {
+        UpdateHeartDisplay(newHealth);
+    }
+
+    private void UpdateHeartDisplay(int newHealth)
+    {
+        foreach (GameObject heart in displayHearts)
+        {
+            Destroy(heart);
+        }
+
+        for (int i = 0; i < newHealth; i++)
+        {
+            GameObject newHeart = Instantiate(heartPrefab, transform);
+            Vector3 heartPos = heartDisplayPos.localPosition + new Vector3(50 * i, 0, 0);
+            newHeart.transform.localPosition = heartPos;
+        }
+    }
+}

--- a/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
+++ b/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
@@ -15,6 +15,12 @@ public class HealthDisplayManager : MonoBehaviour
         healthManager.OnHealthChange.AddListener(OnHealthUpdate);
     }
 
+    private void Start()
+    {
+        // Disables the editor text
+        heartDisplayPos.gameObject.SetActive(false);
+    }
+
     private void OnHealthUpdate(int oldHealth, int newHealth)
     {
         if (oldHealth == newHealth) return;

--- a/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
+++ b/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -8,6 +9,7 @@ public class HealthDisplayManager : MonoBehaviour
     [SerializeField] private GameObject heartPrefab;
     [SerializeField] private float heartDisplayOffset;
     [SerializeField] private Transform heartDisplayPos;
+    [SerializeField] private Image deathScreen;
     private List<GameObject> displayHearts = new List<GameObject>();
 
     private void Awake()
@@ -19,6 +21,8 @@ public class HealthDisplayManager : MonoBehaviour
     {
         // Disables the editor text
         heartDisplayPos.gameObject.SetActive(false);
+        healthManager.StartDeathFade.AddListener((float time) => StartCoroutine(FadeScreen(time, 1)));
+        healthManager.OnDie.AddListener(() => StartCoroutine(FadeScreen(healthManager.deathFadeTimer, -1)));
     }
 
     private void OnHealthUpdate(int oldHealth, int newHealth)
@@ -43,6 +47,26 @@ public class HealthDisplayManager : MonoBehaviour
             Vector3 heartPos = heartDisplayPos.localPosition + new Vector3(50 * i, 0, 0);
             newHeart.transform.localPosition = heartPos;
             displayHearts.Add(newHeart);
+        }
+    }
+
+    /// <summary>
+    /// Fades screen to or from black over the time, the direction picks what way it fades, positive 1 for black, negative 1 for clear.
+    /// </summary>
+    /// <param name="time"></param>
+    /// <param name="direction"></param>
+    /// <returns></returns>
+    public IEnumerator FadeScreen(float time, int direction)
+    {
+        direction = Mathf.Clamp(direction, -1, 1);
+
+        // Checks if the colour is 1 or 0 alpha
+        while (deathScreen.color.a != ((direction + 1) / 2))
+        {
+            deathScreen.color = deathScreen.color + new Color(0, 0, 0, (direction * Time.deltaTime) / time);
+            //Debug.Log((direction * Time.deltaTime) / time);
+            deathScreen.color = new Color(0, 0, 0, Mathf.Clamp(deathScreen.color.a, 0, 1));
+            yield return null;
         }
     }
 }

--- a/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
+++ b/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
@@ -17,6 +17,8 @@ public class HealthDisplayManager : MonoBehaviour
 
     private void OnHealthUpdate(int oldHealth, int newHealth)
     {
+        if (oldHealth == newHealth) return;
+
         UpdateHeartDisplay(newHealth);
     }
 
@@ -27,11 +29,14 @@ public class HealthDisplayManager : MonoBehaviour
             Destroy(heart);
         }
 
+        displayHearts.Clear();
+
         for (int i = 0; i < newHealth; i++)
         {
             GameObject newHeart = Instantiate(heartPrefab, transform);
             Vector3 heartPos = heartDisplayPos.localPosition + new Vector3(50 * i, 0, 0);
             newHeart.transform.localPosition = heartPos;
+            displayHearts.Add(newHeart);
         }
     }
 }

--- a/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
+++ b/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs
@@ -44,7 +44,7 @@ public class HealthDisplayManager : MonoBehaviour
         for (int i = 0; i < newHealth; i++)
         {
             GameObject newHeart = Instantiate(heartPrefab, transform);
-            Vector3 heartPos = heartDisplayPos.localPosition + new Vector3(50 * i, 0, 0);
+            Vector3 heartPos = heartDisplayPos.localPosition + new Vector3(heartDisplayOffset * i, 0, 0);
             newHeart.transform.localPosition = heartPos;
             displayHearts.Add(newHeart);
         }

--- a/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs.meta
+++ b/Assets/Scripts/Health And Hazzards/HealthDisplayManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2682b68b71b5bf34c814207e4ed321cf

--- a/Assets/Scripts/Health And Hazzards/HealthManager.cs
+++ b/Assets/Scripts/Health And Hazzards/HealthManager.cs
@@ -1,21 +1,60 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.Events;
 
 public class HealthManager : MonoBehaviour
 {
-    [HideInInspector] public UnityEvent<int, int> OnHealthChange;
-
+    [SerializeField] private string damageTag;
     [SerializeField] private int maxHealth;
+    [SerializeField] public float deathFadeTimer;
+    [SerializeField] private float fullFadeWait;
+
+    [HideInInspector] public UnityEvent<int, int> OnHealthChange;
+    [HideInInspector] public UnityEvent OnDie;
+    [HideInInspector] public UnityEvent<float> StartDeathFade;
     private int health;
     public int Health { get => health; private set
         {
             int oldHealth = health;
             health = value;
             OnHealthChange?.Invoke(oldHealth, health);
+
+            if (health == 0)
+            {
+                StartDeathFade?.Invoke(deathFadeTimer);
+            }
         }
     }
 
     void Start()
+    {
+        Health = maxHealth;
+        StartDeathFade.AddListener((float time) => StartCoroutine(DeathFade(time)));
+        OnDie.AddListener(OnDeath);
+    }
+
+    private void DamagePlayer(int amount)
+    {
+        Health -= amount;
+    }
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        if (collision.gameObject.CompareTag(damageTag))
+        {
+            DamagePlayer(1);
+        }
+    }
+
+    private IEnumerator DeathFade(float time)
+    {
+        yield return new WaitForSeconds(time + fullFadeWait);
+
+        OnDie?.Invoke();
+        // go to spawn point
+    }
+
+    private void OnDeath()
     {
         Health = maxHealth;
     }

--- a/Assets/Scripts/Health And Hazzards/HealthManager.cs
+++ b/Assets/Scripts/Health And Hazzards/HealthManager.cs
@@ -3,14 +3,15 @@ using UnityEngine.Events;
 
 public class HealthManager : MonoBehaviour
 {
-    public UnityEvent<int> OnHealthChange;
+    [HideInInspector] public UnityEvent<int, int> OnHealthChange;
 
     [SerializeField] private int maxHealth;
     private int health;
     public int Health { get => health; private set
         {
+            int oldHealth = health;
             health = value;
-            OnHealthChange?.Invoke(health);
+            OnHealthChange?.Invoke(oldHealth, health);
         }
     }
 

--- a/Assets/Scripts/Health And Hazzards/HealthManager.cs
+++ b/Assets/Scripts/Health And Hazzards/HealthManager.cs
@@ -21,7 +21,7 @@ public class HealthManager : MonoBehaviour
 
             if (health == 0)
             {
-                StartDeathFade?.Invoke(deathFadeTimer);
+                StartDeathFade?.Invoke(deathFadeTimer);// Disable player controls when this happens and add the poof for example
             }
         }
     }

--- a/Assets/Scripts/Health And Hazzards/HealthManager.cs
+++ b/Assets/Scripts/Health And Hazzards/HealthManager.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+public class HealthManager : MonoBehaviour
+{
+    public UnityEvent<int> OnHealthChange;
+
+    [SerializeField] private int maxHealth;
+    private int health;
+    public int Health { get => health; private set
+        {
+            health = value;
+            OnHealthChange?.Invoke(health);
+        }
+    }
+
+    void Start()
+    {
+        Health = maxHealth;
+    }
+}

--- a/Assets/Scripts/Health And Hazzards/HealthManager.cs.meta
+++ b/Assets/Scripts/Health And Hazzards/HealthManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f81640f39f926ce449ecb17506d3e6dc

--- a/Assets/Scripts/Health And Hazzards/SpawnPoint.cs
+++ b/Assets/Scripts/Health And Hazzards/SpawnPoint.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+public class SpawnPoint : MonoBehaviour
+{
+    [SerializeField] private SpawnPointManager spawnPointManager;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.gameObject.CompareTag("Player"))
+        {
+            spawnPointManager.SetNewSPawnPoint(this);
+        }
+    }
+}

--- a/Assets/Scripts/Health And Hazzards/SpawnPoint.cs.meta
+++ b/Assets/Scripts/Health And Hazzards/SpawnPoint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef510a15720246d43bd8dadaaadeb5c9

--- a/Assets/Scripts/Health And Hazzards/SpawnPointManager.cs
+++ b/Assets/Scripts/Health And Hazzards/SpawnPointManager.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public class SpawnPointManager : MonoBehaviour
+{
+    [SerializeField] private HealthManager healthManager;
+
+    private SpawnPoint spawnPoint;
+
+    private void Start()
+    {
+        healthManager.OnDie.AddListener(Respawn);
+    }
+
+    public void SetNewSPawnPoint(SpawnPoint spawnPoint)
+    {
+        this.spawnPoint = spawnPoint;
+    }
+
+    public void Respawn()
+    {
+        healthManager.transform.position = spawnPoint.transform.position;
+    }
+}

--- a/Assets/Scripts/Health And Hazzards/SpawnPointManager.cs.meta
+++ b/Assets/Scripts/Health And Hazzards/SpawnPointManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: af7ab404c06d0c14ca3a7b707cf0f899

--- a/Assets/UI/Heart.prefab
+++ b/Assets/UI/Heart.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4817011841326584750
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8122007749044218742}
+  - component: {fileID: 8153158404083169718}
+  - component: {fileID: 4717771975720365151}
+  m_Layer: 0
+  m_Name: Heart
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8122007749044218742
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4817011841326584750}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.000010860349}
+  m_LocalScale: {x: 1.1853164, y: 1.1853163, z: 1.1853163}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -360, y: 181}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8153158404083169718
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4817011841326584750}
+  m_CullTransparentMesh: 0
+--- !u!114 &4717771975720365151
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4817011841326584750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 05eb93f533071b6478416d5a83d6221e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/UI/Heart.prefab.meta
+++ b/Assets/UI/Heart.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ad14ff4505b392544b32062ab37aa143
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 3
-  tags: []
+  tags:
+  - Damager
   layers:
   - Default
   - TransparentFX

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -4,7 +4,7 @@
 TagManager:
   serializedVersion: 3
   tags:
-  - Damager
+  - Hazard
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## Issue
Make hazard collisions that when you hit health is removed from the player and you are reset to your last spawn point.

## Changes
* Health is now managed and can go up and down.
* Hearts in the top left are displayed procedurally based on how much health there is
*  On death, there is a fade to black and an event which is called
* After fade to black you go to your most recent spawn point
* Spawn point is modified when you go into a new area based on the trigger around the spawn point
* Hazards now hurt you by one health

Closes #13 